### PR TITLE
Patch fixes

### DIFF
--- a/isofit/atmosphere/atmosphere.py
+++ b/isofit/atmosphere/atmosphere.py
@@ -143,6 +143,10 @@ class BaseAtmosphere(Reader):
             else full_config.forward_model.instrument.get("interpolator_style")
         )
 
+        self.multipart_transmittance = (
+            full_config.forward_model.atmosphere.multipart_transmittance
+        )
+
         self.coupling_terms = ["dir-dir", "dif-dir", "dir-dif", "dif-dif"]
         self.rt_mode = self.config.rt_mode or "transm"
 

--- a/isofit/atmosphere/atmosphere.py
+++ b/isofit/atmosphere/atmosphere.py
@@ -32,6 +32,7 @@ import numpy as np
 
 from isofit.core import common, units
 from isofit.core.common import svd_inv_sqrt
+from isofit.core.geometry import Geometry
 from isofit.luts import LUT, Reader, sub
 
 # Logger = logging.getLogger(__file__)
@@ -110,7 +111,7 @@ class BaseAtmosphere(Reader):
         wl: np.array = [],  # Wavelength override
         fwhm: np.array = [],  # fwhm override
         n_cores: int = None,  # n_core override
-        build_interpolators: bool = True
+        build_interpolators: bool = True,
     ):
         self.config = full_config.forward_model.atmosphere
 
@@ -194,15 +195,15 @@ class BaseAtmosphere(Reader):
         self.bvec = self.config.unknowns.get_element_names()
         self.bval = np.array([x for x in self.config.unknowns.get_elements()[0]])
         # Create LUT (for generic this will be fake executed
-        self.lut_names = set(list(self.lut_grid.keys()) or self.config.statevector_names)
+        self.lut_names = set(
+            list(self.lut_grid.keys()) or self.config.statevector_names
+        )
         self.n_lut_input_dim = len(self.lut_names)
         self.keys = Keys
 
         # Wrapper for the create-load logic that depends on the engine
         # create_lut will include the build logic within engines
-        self.lut = self._lut(
-            build_interpolators=build_interpolators
-        )
+        self.lut = self._lut(build_interpolators=build_interpolators)
         Logger.info("LUT grid loaded from file")
 
         # remove 'point' if added to lut_names after subsetting
@@ -272,16 +273,11 @@ class BaseAtmosphere(Reader):
         if "observer_zenith" in self.lut_grid.keys():
             if any(np.array(self.lut_grid["observer_zenith"]) > 90.0):
                 indices.convert_observer_zenith = [
-                    i
-                    for i in indices.geom
-                    if indices.geom[i] == "observer_zenith"
+                    i for i in indices.geom if indices.geom[i] == "observer_zenith"
                 ][0]
 
         # If it wasn't a geom key, it's x_RT
-        indices.x_RT = list(
-            set(range(self.n_lut_input_dim))
-            - set(indices.geom)
-        )
+        indices.x_RT = list(set(range(self.n_lut_input_dim)) - set(indices.geom))
 
         # Make sure the length of the config statevectores match the engine's assumed statevectors
         if (expected := len(self.statevec_names)) != (got := len(indices.x_RT)):
@@ -291,12 +287,7 @@ class BaseAtmosphere(Reader):
 
         # Load LUT and run coupling function in one go
         # TODO formalize pathway for pre-built LUT
-        ds = self.couple(
-            self.load(
-                file=self.lut_path,
-                subset=self.config.lut_names
-            )
-        )
+        ds = self.couple(self.load(file=self.lut_path, subset=self.config.lut_names))
 
         # Limit the wavelength per the config, does not affect data on disk
         if self.config.wavelength_range is not None:
@@ -310,12 +301,7 @@ class BaseAtmosphere(Reader):
         )
         Logger.debug(f"Interpolators built")
 
-        return LUT(
-            ds,
-            self.n_lut_input_dim,
-            indices,
-            lut_interpolators=interpolators
-        )
+        return LUT(ds, self.n_lut_input_dim, indices, lut_interpolators=interpolators)
 
     def xa(self):
         """Pull the priors from each of the individual RTs."""
@@ -341,7 +327,7 @@ class BaseAtmosphere(Reader):
         """
 
         r = self.lut(x_RT, geom)
-        if self.engine.rt_mode == "rdn":
+        if self.rt_mode == "rdn":
             L_atm = r["rhoatm"]
         else:
             rho_atm = r["rhoatm"]

--- a/isofit/atmosphere/atmosphere.py
+++ b/isofit/atmosphere/atmosphere.py
@@ -30,6 +30,7 @@ from types import SimpleNamespace
 
 import numpy as np
 
+from isofit.configs import Config
 from isofit.core import common, units
 from isofit.core.common import svd_inv_sqrt
 from isofit.core.geometry import Geometry
@@ -99,10 +100,9 @@ class BaseAtmosphere(Reader):
         "surface_elevation_km",
     ]
 
-    # These properties enable easy access to the lut data
-    # TODO Having hard time unpacking this syntax
-    # coszen = property(lambda self: self["coszen"])
-    # solar_irr = property(lambda self: self["solar_irr"])
+    @property
+    def solar_irr(self) -> np.ndarray:
+        return np.array(self.lut["solar_irr"])
 
     def __init__(
         self,

--- a/isofit/atmosphere/engines/libradtran.py
+++ b/isofit/atmosphere/engines/libradtran.py
@@ -45,7 +45,7 @@ class LibRadTranRT(BaseAtmosphere, Writer):
         super().__init__(full_config, **kwargs)
 
         # TODO Add check that sim path exists
-        self.sim_path = self.config_atmosphere.sim_path
+        self.sim_path = self.config.sim_path
 
         self.albedos = [0.0, 0.1, 0.5]
         self.wl_1 = 340.0

--- a/isofit/atmosphere/engines/sRTMnet.py
+++ b/isofit/atmosphere/engines/sRTMnet.py
@@ -406,7 +406,7 @@ class SimulatedModtranRT(BaseAtmosphere, Writer):
 
         # Extract useful information from the sim
         self.esd = sim.esd
-        self.sim_lut_path = config.lut_path
+        self.sim_lut_path = self.config.lut_path
 
         # Prepare the sim results for the emulator
         # In some atmospheres the values get down to basically 0, which 6S can’t quite handle and will resolve to NaN instead of 0
@@ -422,10 +422,10 @@ class SimulatedModtranRT(BaseAtmosphere, Writer):
 
         # Convert our irradiance to date 0 then back to current date
         # sc - If statement to make sure tsis solar model is used if supplied
-        if os.path.basename(config.irradiance_file) == "tsis_f0_0p1.txt":
+        if os.path.basename(self.config.irradiance_file) == "tsis_f0_0p1.txt":
             # Load coarser TSIS model to match emulator expectations
             _, sol_irr = np.loadtxt(
-                os.path.split(config.irradiance_file)[0] + "/tsis_f0_0p5.txt"
+                os.path.split(self.config.irradiance_file)[0] + "/tsis_f0_0p5.txt"
             ).T
             sol_irr = sol_irr / 10  # Convert to uW cm-2 sr-1 nm-1
         else:

--- a/isofit/atmosphere/engines/sRTMnet.py
+++ b/isofit/atmosphere/engines/sRTMnet.py
@@ -32,9 +32,9 @@ import torch
 import yaml
 
 from isofit.atmosphere import BaseAtmosphere
+from isofit.atmosphere.engines import SixSRT
 from isofit.core import units
 from isofit.core.common import calculate_resample_matrix, resample_spectrum
-from isofit.atmosphere.engines import SixSRT
 from isofit.luts import Writer
 
 # Logger = logging.getLogger(__file__)
@@ -264,7 +264,7 @@ class SRTMnetModel(torch.nn.Module):
                     for _ckey, ckey in enumerate(self.component_keys):
                         outdict[ckey].append(
                             self.batch_resample(
-                                out[:, _ckey * nc:(_ckey + 1) * nc],
+                                out[:, _ckey * nc : (_ckey + 1) * nc],
                                 convert_to_rdn=False,
                                 resample_dict=resample_dict,
                             )
@@ -348,9 +348,7 @@ class SimulatedModtranRT(BaseAtmosphere, Writer):
             self.component_mode = "6c"
 
         else:
-            raise ValueError(
-                "Invalid extension for emulator aux file. Use .npz or .6c"
-            )
+            raise ValueError("Invalid extension for emulator aux file. Use .npz or .6c")
 
         # Pack the emulator Aux the same regardless of input file type.
         # Enforce types
@@ -398,7 +396,7 @@ class SimulatedModtranRT(BaseAtmosphere, Writer):
             wl=self.sim_wl,
             fwhm=self.sim_fwhm,
             modtran_emulation=True,
-            build_interpolators=False
+            build_interpolators=False,
         )
 
         if self.config.configure_and_exit:
@@ -435,7 +433,7 @@ class SimulatedModtranRT(BaseAtmosphere, Writer):
         sol_irr = sol_irr * irr_ref**2 / irr_cur**2
 
         self.emulator_sol_irr = sol_irr
-        self.emulator_coszen = sim["coszen"]
+        self.emulator_coszen = float(sim.lut["coszen"])
         self.emulator_H = calculate_resample_matrix(self.emu_wl, self.wl, self.fwhm)
 
         # Pack into dictionary for passing convenience to torch

--- a/isofit/atmosphere/engines/six_s.py
+++ b/isofit/atmosphere/engines/six_s.py
@@ -83,15 +83,15 @@ class SixSRT(BaseAtmosphere, Writer):
 
         self.modtran_emulation = modtran_emulation
 
-        self.wl = wl
-        self.fwhm = fwhm
-
         # Overwrite the wavelengths, because we're going to use these no matter what (6S runs at 2.5 nm)
         # NOTE - this wavelength range is fairly inclusive, but need not be hardcoded at these start and end points
         if not any(wl):
             wl = np.arange(350, 2500 + 2.5, 2.5)
         if not any(fwhm):
-            fwhm = np.full(self.wl.size, 2.0)
+            fwhm = np.full(wl.size, 2.0)
+
+        self.wl = wl
+        self.fwhm = fwhm
 
         super().__init__(full_config, wl=self.wl, fwhm=self.fwhm, **kwargs)
 

--- a/isofit/atmosphere/engines/six_s.py
+++ b/isofit/atmosphere/engines/six_s.py
@@ -104,7 +104,7 @@ class SixSRT(BaseAtmosphere, Writer):
             self.co2_mode = True
 
         # TODO Add check that sim path exists
-        self.sim_path = self.config_atmosphere.sim_path
+        self.sim_path = self.config.sim_path
 
         # If the LUT file already exists, still need to calc this post init
         if not hasattr(self, "esd"):

--- a/isofit/atmosphere/engines/six_s.py
+++ b/isofit/atmosphere/engines/six_s.py
@@ -28,7 +28,7 @@ import numpy as np
 
 from isofit.atmosphere import BaseAtmosphere
 from isofit.core import units
-from isofit.core.common import resample_spectrum, load_esd
+from isofit.core.common import load_esd, resample_spectrum
 from isofit.data import env
 from isofit.data.cli.sixs import get_exe
 from isofit.luts import Writer
@@ -83,15 +83,15 @@ class SixSRT(BaseAtmosphere, Writer):
 
         self.modtran_emulation = modtran_emulation
 
+        self.wl = wl
+        self.fwhm = fwhm
+
         # Overwrite the wavelengths, because we're going to use these no matter what (6S runs at 2.5 nm)
         # NOTE - this wavelength range is fairly inclusive, but need not be hardcoded at these start and end points
         if not any(wl):
             wl = np.arange(350, 2500 + 2.5, 2.5)
         if not any(fwhm):
             fwhm = np.full(self.wl.size, 2.0)
-
-        self.wl = wl
-        self.fwhm = fwhm
 
         super().__init__(full_config, wl=self.wl, fwhm=self.fwhm, **kwargs)
 

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -158,9 +158,6 @@ class ForwardModel:
         else:
             self.model_discrepancy = None
 
-        # Special run modes:
-        self.multipart_transmittance = full_config.forward_model.multipart_transmittance
-
     def out_of_bounds(self, x):
         """Check if state vector is within bounds."""
 

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -340,7 +340,7 @@ class ForwardModel:
                 r, geom, rho_dif_dif=rho_dif_dif
             )
         else:
-            if self.atmosphere.atmosphere_mode == "rdn":
+            if self.atmosphere.rt_mode == "rdn":
                 L_tot = r["transm_down_dif"]
             else:
                 L_tot = transm_to_rdn(
@@ -390,7 +390,7 @@ class ForwardModel:
                 transm_to_rdn(
                     r[key], coszen=geom.coszen, solar_irr=self.atmosphere.solar_irr
                 )
-                if self.atmosphere.atmosphere_mode == "transm"
+                if self.atmosphere.rt_mode == "transm"
                 else r[key]
             )
 


### PR DESCRIPTION
Adds some small fixes throughout.  Check carefully, these were my attempts:

- multipart_transmittance moved from forward to atmosphere (there were inconsistent references)
- solar_irr property on atmosphere added (needs verification)
- removed coszen from atmosphere, as we now use geometry.  Only exception is sRTMnet emulator_coszen....this I pulled from sim.lut.  Not 100% sure this is the right move
- corrects various self references / variable assignment order pieces